### PR TITLE
Fully implement decoding of HTML entities

### DIFF
--- a/tests/test_click.py
+++ b/tests/test_click.py
@@ -130,3 +130,8 @@ class TestClick(unittest.TestCase):
         self.assertEqual(_parse_attrs("href='foo' id=\"bar\" "), {'href': 'foo', 'id': 'bar'})
         self.assertEqual(_parse_attrs("href='foo' id='bar' "), {'href': 'foo', 'id': 'bar'})
         self.assertEqual(_parse_attrs("tag='foo\"'"), {'tag': 'foo"'})
+        self.assertEqual(
+            _parse_attrs('value="&lt;&gt;&amp;&quot;&#123;"'),
+                {'value': u('<>&"{')})
+        self.assertEqual(_parse_attrs('value="&sum;"'), {'value': u('∑')})
+        self.assertEqual(_parse_attrs('value="&#x20ac;"'), {'value': u('€')})

--- a/webtest/compat.py
+++ b/webtest/compat.py
@@ -8,6 +8,7 @@ if sys.version_info[0] > 2:
     binary_type = bytes
     from json import loads
     from json import dumps
+    from html.entities import name2codepoint
     from io import StringIO
     from io import BytesIO
     from urllib.parse import urlencode
@@ -40,6 +41,7 @@ else:
     string_types = basestring
     text_type = unicode
     binary_type = str
+    from htmlentitydefs import name2codepoint
     from urllib import splittype
     from urllib import splithost
     from urllib import urlencode


### PR DESCRIPTION
Currently webtest.app.html_unquote only handles a few of the most common character entity references.

This pull request adds support for all character entity references defined in html.entities, as well as numeric entity references (decimal and hex).

Added tests alongside some exercising _parse_attrs, which calls html_unquote to unquote attribute values.
