### PR TITLE
Fix PyPy issue

### DIFF
--- a/webtest/ext.py
+++ b/webtest/ext.py
@@ -100,7 +100,7 @@ def casperjs(test_app):
                     stderr=subprocess.PIPE)
             p.wait()
             output = p.stdout.read()
-            if to_bytes('FAIL') in output:
+            if to_bytes('FAIL') in output or to_bytes('Fatal') in output:
                 print(to_string(output))
 
                 raise AssertionError(


### PR DESCRIPTION
This fixes one of the issues with running the tests on PyPy (issue #11), mainly that a socket
for the WSGI server started in the CasperJS tests wasn't explicitly closed.

I also added a check for Fatal errors encountered when running PhantomJS (e.g., when the binary is not marked executable).

Even with this fix, there are at least 2 other issues I encountered when running the tests under
PyPy:
- The PhantomJS buildout recipe on pypi seems busted, and does not chmod the PhantomJS binary even though its changelog indicates it is supposed to.
- Another test fails because lxml is not built.
