### PR TITLE
Make tox work for py32 and py33

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py32,py26,py27,cover
+envlist=py33,py32,py26,py27,cover
 
 [testenv:py32]
 basepython=python3.2
@@ -7,7 +7,7 @@ changedir={toxinidir}
 commands =
     rm -f .installed.cfg
     python3.2 bootstrap-py3k.py buildout:parts-directory={envdir}/parts buildout:bin-directory={envbindir}
-    {envbindir}/buildout buildout:parts-directory={envdir}/parts buildout:bin-directory={envbindir}
+    {envbindir}/buildout buildout:parts-directory={envdir}/parts buildout:bin-directory={envbindir} buildout:versions=versions versions:zc.buildout=2.0.0a2 versions:zc.recipe.egg=2.0.0a2
     {envbindir}/nosetests
 
 [testenv:py33]
@@ -16,7 +16,7 @@ changedir={toxinidir}
 commands =
     rm -f .installed.cfg
     python3.3 bootstrap-py3k.py buildout:parts-directory={envdir}/parts buildout:bin-directory={envbindir}
-    {envbindir}/buildout buildout:parts-directory={envdir}/parts buildout:bin-directory={envbindir}
+    {envbindir}/buildout buildout:parts-directory={envdir}/parts buildout:bin-directory={envbindir} buildout:versions=versions versions:zc.buildout=2.0.0a1 versions:zc.recipe.egg=2.0.0a3
     {envbindir}/nosetests
 
 [testenv:py26]


### PR DESCRIPTION
by passing in specific versions of `zc.buildout` and `zc.recipe.egg` to use to `buildout` command in `tox.ini`

Fixes #20.
