### PR TITLE
Combine coverage results, enable nose xunit output.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,80 +1,58 @@
 [tox]
-envlist=py32,py33,py26,py27
+envlist=py32,py33,py26,py27,coverage
 
-[testenv:py32]
-basepython=python3.2
-changedir={toxinidir}
+[testenv]
 commands =
   {toxinidir}/tests/bootstrap.sh
-  {envbindir}/nosetests []
+  {envbindir}/coverage run --source=webtest {envbindir}/nosetests --with-xunit --xunit-file=nosetests-{envname}.xml []
+  {envbindir}/coverage xml -o coverage-{envname}.xml
+  {envbindir}/coverage report
+setenv =
+  SELENIUM_DRIVER=firefox
+  COVERAGE_FILE=.coverage.{envname}
+
+[common]
 deps =
   lxml
   pyquery
   BeautifulSoup4
-  unittest2py3k
   nose
-setenv =
-  SELENIUM_DRIVER=firefox
+  coverage
 
-
-[testenv:py33]
-basepython=python3.3
-changedir={toxinidir}
-commands =
-  {toxinidir}/tests/bootstrap.sh
-  {envbindir}/nosetests []
+[PY2]
 deps =
-  lxml
-  pyquery
-  BeautifulSoup4
-  unittest2py3k
-  nose
-setenv =
-  SELENIUM_DRIVER=firefox
+    unittest2
 
+[PY3]
+deps =
+    unittest2py3k
+    
 [testenv:py26]
-basepython=python2.6
-changedir={toxinidir}
-commands =
-  {toxinidir}/tests/bootstrap.sh
-  {envbindir}/nosetests []
 deps =
-  lxml
-  pyquery
-  BeautifulSoup4
-  unittest2
-  nose
-setenv =
-  SELENIUM_DRIVER=firefox
+    {[common]deps}
+    {[PY2]deps}
 
 [testenv:py27]
-basepython=python2.7
-changedir={toxinidir}
-commands =
-  {toxinidir}/tests/bootstrap.sh
-  {envbindir}/nosetests --with-xunit --with-xcoverage []
 deps =
-  lxml
-  pyquery
-  BeautifulSoup4
-  unittest2
-  nose
-  nosexcover
-setenv =
-  SELENIUM_DRIVER=firefox
+    {[common]deps}
+    {[PY2]deps}
 
-[testenv:pypy]
-basepython=pypy
-changedir={toxinidir}
-commands =
-  {toxinidir}/tests/bootstrap.sh
-  {envbindir}/nosetests --with-xunit --with-xcoverage []
+[testenv:py32]
 deps =
-  lxml
-  pyquery
-  BeautifulSoup4
-  unittest2
-  nose
-  nosexcover
+    {[common]deps}
+    {[PY3]deps}
+
+[testenv:py33]
+deps =
+    {[common]deps}
+    {[PY3]deps}
+
+[testenv:coverage]
+deps =
+    coverage
 setenv =
-  SELENIUM_DRIVER=firefox
+  COVERAGE_FILE=.coverage
+commands =
+    {envbindir}/coverage combine
+    {envbindir}/coverage xml
+    {envbindir}/coverage report


### PR DESCRIPTION
The coverage results of each python versions are saved in different
coverage files, and combined in the 'coverage' test which is runned last.

Also output the nosetests xml results in different files.
