### PR TITLE
Allow TestResponse.click() to match HTML content as well as text content...

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,8 +4,7 @@ News
 2.0.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+* Allow TestResponse.click() to match HTML content again.
 
 2.0.1 (2013-03-05)
 ------------------

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -91,6 +91,14 @@ def links_app(environ, start_response):
                     <form method="POST" id="second_form"></form>
                 </body>
             </html>
+        """,
+        '/html_in_anchor/': """
+            <html>
+                <head><title>Page with HTML in an anchor tag</title></head>
+                <body>
+                    <a href='/foo/'>Foo Bar<span class='baz qux'>Quz</span></a>
+                </body>
+            </html>
         """
     }
 
@@ -177,6 +185,14 @@ class TestResponse(unittest.TestCase):
             'Just eggs.',
             app.get('/').click('Click me!', index=1)
         )
+        self.assertIn(
+            'This is foo.',
+            app.get('/html_in_anchor/').click('baz qux')
+        )
+
+        def dont_match_anchor_tag():
+            app.get('/html_in_anchor/').click('href')
+        self.assertRaises(IndexError, dont_match_anchor_tag)
 
         def multiple_links():
             app.get('/').click('Click me!')

--- a/webtest/response.py
+++ b/webtest/response.py
@@ -193,7 +193,7 @@ class TestResponse(webob.Response):
         total_links = 0
         for element in self.html.find_all(tag):
             el_html = str(element)
-            el_content = element.get_text()
+            el_content = element.decode_contents()
             attrs = element
             if verbose:
                 printlog('Element: %r' % el_html)


### PR DESCRIPTION
This brings TestResponse.click() in alignment with the documentation,
which states that description will match "HTML and all".

Discovered this while trying to match anchor tags that have no consistently identifiable text content, but has a consistent innerHTML element.

https://github.com/Pylons/webtest/blob/master/webtest/response.py#L130
