### PR TITLE
Support secure cookies

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,8 @@ News
 
 * Allow TestResponse.click() to match HTML content again.
 
+* Support secure cookies [Andrey Lebedev]
+
 2.0.1 (2013-03-05)
 ------------------
 

--- a/webtest/utils.py
+++ b/webtest/utils.py
@@ -123,6 +123,21 @@ class _RequestCookieAdapter(object):
     def has_header(self, key):
         return key in self._request.headers
 
+    def get_host(self):
+        return self._request.host
+
+    def get_type(self):
+        return self._request.scheme
+
+    @property
+    def type(self):  # NOQA
+        # This is undocumented method that Python 3 cookielib uses
+        return self.get_type()
+
+    def header_items(self):
+        return self._request.headers.items()
+
+
 
 class _ResponseCookieAdapter(object):
     """


### PR DESCRIPTION
When I try to call application using webtest and have secure cookies in cookiejar, I'm getting the following exception:

```
      File "<doctest cookies.txt[165]>", line 1, in <module>
        browser.open('https://dev.example.org/get_cookie.html')
      File "/home/andrey/projects/zope/zope.testbrowser/src/zope/testbrowser/browser2.py", line 138, in open
        self._response = self.testapp.get(url, **reqargs)
      File "/home/andrey/.buildout/eggs/WebTest-2.0.1-py2.7.egg/webtest/app.py", line 199, in get
        expect_errors=expect_errors)
      File "/home/andrey/.buildout/eggs/WebTest-2.0.1-py2.7.egg/webtest/app.py", line 461, in do_request
        self.cookiejar.add_cookie_header(utils._RequestCookieAdapter(req))
      File "/usr/lib/python2.7/cookielib.py", line 1324, in add_cookie_header
        cookies = self._cookies_for_request(request)
      File "/usr/lib/python2.7/cookielib.py", line 1250, in _cookies_for_request
        cookies.extend(self._cookies_for_domain(domain, request))
      File "/usr/lib/python2.7/cookielib.py", line 1239, in _cookies_for_domain
        if not self._policy.return_ok(cookie, request):
      File "/usr/lib/python2.7/cookielib.py", line 1071, in return_ok
        if not fn(cookie, request):
      File "/usr/lib/python2.7/cookielib.py", line 1097, in return_ok_secure
        if cookie.secure and request.get_type() != "https":
    AttributeError: '_RequestCookieAdapter' object has no attribute 'get_type'
```

This is due to incomplete urllib2.Request interface implementation by _RequestCookieAdapter, specified at http://docs.python.org/2/library/cookielib.html#cookielib.CookieJar.add_cookie_header. 

The commit fixes the problem and adds a regression test.

Please pull.
