### PR TITLE
Buttons are not treated as submit controls

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,8 @@ News
 2.0.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+* <button> without type='submit' attribute is treated as Submit 
+  control [Andrey Lebedev].
 
 
 2.0.3 (2013-03-19)

--- a/tests/html/form_inputs.html
+++ b/tests/html/form_inputs.html
@@ -10,6 +10,7 @@
             <input type="file" name="file" />
             <input type="unknown" name="unknown" />
             <input type="submit" name="submit" />
+            <button name='button'>Button</button>
         </form>
         <form method="POST" id="text_input_form">
             <input name="foo" type="text" value="bar">

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -12,7 +12,7 @@ from six import PY3
 from webob import Request
 from webtest.debugapp import DebugApp
 from webtest.compat import to_bytes
-from webtest.forms import NoValue
+from webtest.forms import NoValue, Submit
 from tests.compat import unittest
 from tests.compat import u
 
@@ -32,6 +32,12 @@ class TestForms(unittest.TestCase):
             form['submit'].value__set,
             'foo'
         )
+
+    def test_button(self):
+        form = self.callFUT()
+        button = form['button']
+        self.assertTrue(isinstance(button, Submit),
+                        "<button> without type is a submit button")
 
     def test_force_select(self):
         form = self.callFUT()

--- a/webtest/forms.py
+++ b/webtest/forms.py
@@ -385,6 +385,8 @@ class Form(object):
                 tag_type = 'select'
             if tag_type == "select" and attrs.get("multiple"):
                 tag_type = "multiple_select"
+            if tag == 'button':
+                tag_type = 'submit'
 
             FieldClass = self.FieldClass.classes.get(tag_type,
                                                      self.FieldClass)


### PR DESCRIPTION
`<button>` tags without `type="submit"` attribute are not treated as Submit controls by webtest, which is not how real browsers behave. Also, their values are submitted by other values as if they were text input controls.

Please pull the fix for this problem.
