### PR TITLE
Support for redirects having relative "Location" header

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ News
 2.0.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+* Support for redirects having relative "Location" header [Andrey Lebedev]
 
 
 2.0.3 (2013-03-19)

--- a/webtest/response.py
+++ b/webtest/response.py
@@ -81,10 +81,11 @@ class TestResponse(webob.Response):
 
     def _follow(self, **kw):
         location = self.headers['location']
-        type_, rest = splittype(location)
+        abslocation = urlparse.urljoin(self.request.url, location)
+        type_, rest = splittype(abslocation)
         host, path = splithost(rest)
         # @@: We should test that it's not a remote redirect
-        return self.test_app.get(location, **kw)
+        return self.test_app.get(abslocation, **kw)
 
     def follow(self, **kw):
         """


### PR DESCRIPTION
Location header may contain an URI, relative to last request URL. Current webtest will fail in this case. Fix is attached, please pull.
