### PR TITLE
Correctly handle <option> elements with no value attribute

### DIFF
--- a/webtest/forms.py
+++ b/webtest/forms.py
@@ -411,7 +411,7 @@ class Form(object):
 
             if tag == 'select':
                 for option in node('option'):
-                    field.options.append((option.attrs.get('value'),
+                    field.options.append((option.attrs.get('value', option.text),
                                           'selected' in option.attrs))
 
         self.field_order = field_order


### PR DESCRIPTION
E.g. http://www.w3.org/TR/REC-html40/interact/forms.html#edef-OPTION
clearly states that the value attribute of OPTION elements "defauls to
element content".
