### PR TITLE
Add unicode to METADATA_TYPE

### DIFF
--- a/webtest/lint.py
+++ b/webtest/lint.py
@@ -130,7 +130,7 @@ valid_methods = (
     'TRACE', 'PATCH',
 )
 
-METADATA_TYPE = PY3 and (str, binary_type) or (str,)
+METADATA_TYPE = PY3 and (str, binary_type) or (str, unicode)
 
 # PEP-3333 says that environment variables must be "native strings",
 # i.e. str(), which however is something *different* in py2 and py3.


### PR DESCRIPTION
I'm using webtest to test a Bottle app on python2.7. It seems as if Bottle is setting headers with type `unicode`.
