### PR TITLE
Fix default value for delete params argument.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ News
 
 - Fixed #72. Use WSGIServer new api even if there waitress has backward compat.
   [gawel]
+- Fixed #50. Corrected default value for the delete params argument. [noonat]
 
 
 2.0.6 (2013-05-23)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -12,6 +12,7 @@ import os
 import six
 import mock
 import webtest
+import warnings
 
 
 class TestApp(unittest.TestCase):
@@ -50,6 +51,16 @@ class TestApp(unittest.TestCase):
         resp.mustcontain('a=b', 'c=d')
         resp = self.app.get('/?a=b&c=d', dict(e='f'))
         resp.mustcontain('a=b', 'c=d', 'e=f')
+
+    def test_delete_params_warning(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            self.app.delete('/')
+            self.assertEqual(len(w), 0, "We should not have any warnings")
+            self.app.delete('/', params=dict(a=1))
+            self.assertEqual(len(w), 1, "We should have one warning")
+            self.assertTrue("DELETE" in str(w[-1].message),
+                "The warning message should say something about DELETE")
 
     def test_request_with_testrequest(self):
         req = webtest.TestRequest.blank('/')

--- a/webtest/app.py
+++ b/webtest/app.py
@@ -271,8 +271,9 @@ class TestApp(object):
                                  content_type=content_type,
                                  )
 
-    def delete(self, url, params='', headers=None, extra_environ=None,
-               status=None, expect_errors=False, content_type=None):
+    def delete(self, url, params=utils.NoDefault, headers=None,
+               extra_environ=None, status=None, expect_errors=False,
+               content_type=None):
         """
         Do a DELETE request. Similar to :meth:`~webtest.TestApp.get`.
 


### PR DESCRIPTION
This fixes #50 in Pylons/webtest.
