### PR TITLE
Allow specifying the MIME type of an uploaded file

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,9 @@ News
 - Remove old (and broken?) casperjs/selenium backward compat imports. Fix
   https://github.com/gawel/webtest-selenium/issues/9
 
+- Allow optionally specifying the MIME type of an uploaded form file. Fixes #86
+  [Marius Gedminas]
+
 
 2.0.7 (2013-08-07)
 ------------------

--- a/docs/forms.txt
+++ b/docs/forms.txt
@@ -172,6 +172,7 @@ You can deal with file upload by using the Upload class:
     >>> from webtest import Upload
     >>> form['file'] = Upload('README.rst')
     >>> form['file'] = Upload('README.rst', b'data')
+    >>> form['file'] = Upload('README.rst', b'data', 'text/x-rst')
 
 Submit a form
 --------------

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -44,6 +44,16 @@ class TestApp(unittest.TestCase):
             [(six.b('key'), six.b('value'))], [])
         self.assertIn(to_bytes('name="key"'), data[-1])
 
+    def test_encode_multipart_content_type(self):
+        data = self.app.encode_multipart(
+            [], [('file', 'data.txt', six.b('data'), 'text/x-custom-mime-type')])
+        self.assertIn(to_bytes('Content-Type: text/x-custom-mime-type'), data[-1])
+
+        data = self.app.encode_multipart(
+            [('file', webtest.Upload('data.txt', six.b('data'),
+                                     'text/x-custom-mime-type'))], [])
+        self.assertIn(to_bytes('Content-Type: text/x-custom-mime-type'), data[-1])
+
     def test_get_params(self):
         resp = self.app.get('/', 'a=b')
         resp.mustcontain('a=b')

--- a/webtest/forms.py
+++ b/webtest/forms.py
@@ -16,6 +16,8 @@ class Upload(object):
     """
     A file to upload::
 
+        >>> Upload('filename.txt', 'data', 'application/octet-stream')
+        <Upload "filename.txt">
         >>> Upload('filename.txt', 'data')
         <Upload "filename.txt">
         >>> Upload("README.txt")
@@ -23,17 +25,20 @@ class Upload(object):
 
     :param filename: Name of the file to upload.
     :param content: Contents of the file.
+    :param content_type: MIME type of the file.
 
     """
 
-    def __init__(self, filename, content=None):
+    def __init__(self, filename, content=None, content_type=None):
         self.filename = filename
         self.content = content
+        self.content_type = content_type
 
     def __iter__(self):
         yield self.filename
         if self.content:
             yield self.content
+            # XXX: do we need to yield self.content_type here?
         # TODO: do we handle the case when we need to get
         # contents ourselves?
 


### PR DESCRIPTION
This adds a new optional argument to webtest.forms.Upload() that lets you explicitly specify the content type of the uploaded file.  If not specified or false-ish (None, ''), webtest will continue using mimetypes.guess_type like it used to.

Fixes #86
