### PR TITLE
Make sure Upload.content_type is not ignored

### DIFF
--- a/webtest/forms.py
+++ b/webtest/forms.py
@@ -38,7 +38,7 @@ class Upload(object):
         yield self.filename
         if self.content:
             yield self.content
-            # XXX: do we need to yield self.content_type here?
+            yield self.content_type
         # TODO: do we handle the case when we need to get
         # contents ourselves?
 


### PR DESCRIPTION
Looks like there's a bazillion methods of specifying files you want to
upload with a form, and I missed one of them.  This adds a missing test
case and fixes the bug.

A followup fix for issue #86.
