### PR TITLE
Adds ability to specify an HTML parser

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,9 @@ News
 2.0.10 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Add an optional parameter to `TestApp`, allowing the user to specify the
+  parser used by BeautifulSoup
+  [lyndsysimon]
 
 
 2.0.9 (2013-09-18)

--- a/webtest/app.py
+++ b/webtest/app.py
@@ -106,12 +106,16 @@ class TestApp(object):
         A convenient shortcut for a dict of all cookies in
         ``cookiejar``.
 
+    :param parser_features:
+        Passed to BeautifulSoup when parsing responses.
+    :type parser_features:
+        string or list
     """
 
     RequestClass = TestRequest
 
     def __init__(self, app, extra_environ=None, relative_to=None,
-                 use_unicode=True, cookiejar=None):
+                 use_unicode=True, cookiejar=None, parser_features=None):
         if 'WEBTEST_TARGET_URL' in os.environ:
             app = os.environ['WEBTEST_TARGET_URL']
         if isinstance(app, string_types):
@@ -133,6 +137,8 @@ class TestApp(object):
         self.extra_environ = extra_environ
         self.use_unicode = use_unicode
         self.cookiejar = cookiejar or http_cookiejar.CookieJar()
+        if parser_features:
+            self.RequestClass.ResponseClass.parser_features = parser_features
 
     @property
     def cookies(self):

--- a/webtest/forms.py
+++ b/webtest/forms.py
@@ -357,10 +357,10 @@ class Form(object):
 
     FieldClass = Field
 
-    def __init__(self, response, text):
+    def __init__(self, response, text, parser_features='html.parser'):
         self.response = response
         self.text = text
-        self.html = BeautifulSoup(self.text, "html.parser")
+        self.html = BeautifulSoup(self.text, parser_features)
 
         attrs = self.html('form')[0].attrs
         self.action = attrs.get('action', '')

--- a/webtest/response.py
+++ b/webtest/response.py
@@ -28,6 +28,7 @@ class TestResponse(webob.Response):
 
     request = None
     _forms_indexed = None
+    parser_features = 'html.parser'
 
     @property
     def forms(self):
@@ -75,7 +76,7 @@ class TestResponse(webob.Response):
         forms_ = self._forms_indexed = {}
         form_texts = [str(f) for f in self.html('form')]
         for i, text in enumerate(form_texts):
-            form = forms.Form(self, text)
+            form = forms.Form(self, text, self.parser_features)
             forms_[i] = form
             if form.id:
                 forms_[form.id] = form
@@ -423,7 +424,7 @@ class TestResponse(webob.Response):
             raise AttributeError(
                 "Not an HTML response body (content-type: %s)"
                 % self.content_type)
-        soup = BeautifulSoup(self.testbody, "html.parser")
+        soup = BeautifulSoup(self.testbody, self.parser_features)
         return soup
 
     @property


### PR DESCRIPTION
This addresses an itch of my own - I needed to tell BeautifulSoup to use `html5lib` instead of `http.parse`. There was no way to do so without changing the WebTest codebase, so I added the functionality.
