### PR TITLE
Make StopableWSGIServer thread daemonic

### DIFF
--- a/webtest/http.py
+++ b/webtest/http.py
@@ -116,6 +116,7 @@ class StopableWSGIServer(TcpWSGIServer):
             kwargs['expose_tracebacks'] = True
         server = cls(application, **kwargs)
         server.runner = threading.Thread(target=server.run)
+        server.runner.daemon = True
         server.runner.start()
         return server
 


### PR DESCRIPTION
Ensures that the server thread cannot prevent the process from exiting.
