### PR TITLE
Ignore the value attribute of <input type="file">

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,8 @@ News
 2.0.12 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Ignore the `value` attribute of file inputs
+  [Markus Bertheau]
 
 
 2.0.11 (2013-12-29)

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -679,7 +679,7 @@ class SingleUploadFileApp(object):
     <body>
         <form method="POST" id="file_upload_form"
               enctype="multipart/form-data">
-            <input name="file-field" type="file" />
+            <input name="file-field" type="file" value="some/path/file.txt" />
             <input name="button" type="submit" value="single">
         </form>
     </body>

--- a/webtest/forms.py
+++ b/webtest/forms.py
@@ -415,6 +415,9 @@ class Form(object):
                     field.options.append((attrs.get('value'),
                                           'checked' in attrs))
                     continue
+                elif tag_type == 'file':
+                    if 'value' in attrs:
+                        del attrs['value']
 
             field = FieldClass(self, tag, name, pos, **attrs)
             fields.setdefault(name, []).append(field)


### PR DESCRIPTION
Browsers do the same thing, see
http://stackoverflow.com/questions/20537696/remember-and-repopulate-file-input/20537822#20537822

Without this, submitting the form as is gives
ValueError: upload_files need to be a list of tuples of (fieldname, filename, filecontent, mimetype) or (fieldname, filename, filecontent) or (fieldname, filename); you gave: "['file-field', u's', u'o', u'm', u'e', u'/', u'p', u'a', u't', u'h', u'/', u'f', u'i', u'l', u'e', u"
