### PR TITLE
[Feature] Select option by text

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,8 @@ News
 2.0.13 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Allow selecting <select> options by text
+  [Markus Bertheau]
 
 
 2.0.12 (2014-01-17)

--- a/docs/forms.txt
+++ b/docs/forms.txt
@@ -104,6 +104,14 @@ You can select an option by its text with ``.select()``:
     >>> print(form['select'].value)
     option2
 
+For select multiple use ``.select_multiple()``:
+
+.. code-block:: python
+
+    >>> form.select_multiple('multiple', texts=["Option 1", "Option 2"])
+    >>> print(form['multiple'].value) # doctest: +SKIP
+    [u'option1', u'option2']
+
 Select fields can only be set to valid values (i.e., values in an ``<option>``)
 but you can also use ``.force_value()`` to enter values not present in an
 option.

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -602,6 +602,18 @@ class TestSelect(unittest.TestCase):
         display = multiple_form.submit("button")
         self.assertIn("<p>You selected 9</p>", display, display)
 
+        res = app.get('/')
+        multiple_form = res.forms["multiple_select_form"]
+        self.assertRaises(ValueError, multiple_form.select_multiple,
+                          "multiple",
+                          ["8", "10"], texts=["Eight", "Ten"])
+        self.assertRaises(ValueError, multiple_form.select_multiple,
+                          "multiple", texts=["Twelve"])
+        multiple_form.select_multiple("multiple",
+                                      texts=["Eight", "Nine", "Ten"])
+        display = multiple_form.submit("button")
+        self.assertIn("<p>You selected 8, 9, 10</p>", display, display)
+
     def test_multiple_select_forced_values(self):
         app = webtest.TestApp(select_app)
         res = app.get('/')

--- a/webtest/forms.py
+++ b/webtest/forms.py
@@ -167,6 +167,22 @@ class MultipleSelect(Field):
         self._forced_values = values
         self.selectedIndices = []
 
+    def get_value_for_texts(self, texts):
+        str_texts = [utils.stringify(text) for text in texts]
+        value = []
+        for i, (option, checked, text) in enumerate(self.options):
+            if text in str_texts:
+                value.append(option)
+                str_texts.remove(text)
+
+        if str_texts:
+            raise ValueError(
+                "Option(s) %r not found (from %s)"
+                % (', '.join(str_texts),
+                   ', '.join([repr(t) for o, c, t in self.options])))
+
+        return value
+
     def value__set(self, values):
         str_values = [utils.stringify(value) for value in values]
         self.selectedIndices = []
@@ -539,6 +555,21 @@ class Form(object):
 
         if text is not None:
             value = field.get_value_for_text(text)
+
+        field.value = value
+
+    def select_multiple(self, name, value=None, texts=None, index=None):
+        """Like ``.set()``, except also confirms the target is a
+        ``<select multiple>`` and allows selecting options by text.
+        """
+        field = self.get(name, index=index)
+        assert isinstance(field, MultipleSelect)
+
+        if value is not None and texts is not None:
+            raise ValueError("Specify only one of value and texts.")
+
+        if texts is not None:
+            value = field.get_value_for_texts(texts)
 
         field.value = value
 


### PR DESCRIPTION
I'd argue that the value of a select option is an implementation detail and it's not visible to the user. Therefore it should be easily possible to select a select option by its text.

I could write a pull request that
- makes the `value` argument to `Form.select` optional
- allows a `text` argument for `Form.select`

What are your thoughts?
