### PR TITLE
"200 OK" rather that "200 Ok"

### DIFF
--- a/docs/index.txt
+++ b/docs/index.txt
@@ -80,7 +80,7 @@ Here is a basic application::
     >>> def application(environ, start_response):
     ...     headers = [('Content-Type', 'text/html; charset=utf8'),
     ...                ('Content-Length', str(len(body)))]
-    ...     start_response('200 Ok', headers)
+    ...     start_response('200 OK', headers)
     ...     return [body]
 
 Wrap it into a :class:`~webtest.TestApp`::
@@ -94,7 +94,7 @@ Then you can get the response of a HTTP GET::
 
 And check the results, like response's status::
 
-    >>> assert resp.status == '200 Ok'
+    >>> assert resp.status == '200 OK'
     >>> assert resp.status_int == 200
 
 Response's headers::


### PR DESCRIPTION
 Using the snippet

```
assert resp.status == '200 Ok'
```

in a functional test made me realize that Pyramid outputs `200 OK` rather than `200 Ok`.
This PL fixes the index page (`testresponse.txt` and `forms.txt` already have the correct form)
