### PR TITLE
make wrapping the app in the lint middleware optional

### DIFF
--- a/webtest/app.py
+++ b/webtest/app.py
@@ -115,7 +115,7 @@ class TestApp(object):
     RequestClass = TestRequest
 
     def __init__(self, app, extra_environ=None, relative_to=None,
-                 use_unicode=True, cookiejar=None, parser_features=None):
+                 use_unicode=True, cookiejar=None, parser_features=None, lint=True):
         if 'WEBTEST_TARGET_URL' in os.environ:
             app = os.environ['WEBTEST_TARGET_URL']
         if isinstance(app, string_types):
@@ -131,6 +131,7 @@ class TestApp(object):
                 # __file__
                 app = loadapp(app, relative_to=relative_to)
         self.app = app
+        self.lint = lint
         self.relative_to = relative_to
         if extra_environ is None:
             extra_environ = {}
@@ -489,7 +490,7 @@ class TestApp(object):
         self.cookiejar.add_cookie_header(utils._RequestCookieAdapter(req))
 
         # verify wsgi compatibility
-        app = lint.middleware(self.app)
+        app = lint.middleware(self.app) if self.lint else self.app
 
         ## FIXME: should it be an option to not catch exc_info?
         res = req.get_response(app, catch_exc_info=True)


### PR DESCRIPTION
I am testing my own middlewares and proxies. The responses from my external requests (webob) as not coming back as lint compliant. I like to be able to control how picky my tests are.
