### PR TITLE
Call method as described in documentation.

### DIFF
--- a/webtest/app.py
+++ b/webtest/app.py
@@ -530,7 +530,7 @@ class TestApp(object):
                                expect_errors=expect_errors,
                                )
 
-    def do_request(self, req, status, expect_errors):
+    def do_request(self, req, status=None, expect_errors=None):
         """
         Executes the given webob Request (``req``), with the expected
         ``status``.  Generally :meth:`~webtest.TestApp.get` and


### PR DESCRIPTION
Get  `TypeError: do_request() takes exactly 4 arguments (2 given)` by following the code in document:

```
To use this::

            req = webtest.TestRequest.blank('url', ...args...)
            resp = app.do_request(req)
```

Fix it.
