### PR TITLE
add support for checking custom reason phrase using status parameter

### DIFF
--- a/docs/testapp.rst
+++ b/docs/testapp.rst
@@ -146,6 +146,7 @@ you are testing is something you should avoid).
 
 To indicate another status is expected, use the keyword argument
 ``status=404`` to (for example) check that it is a 404 status, or
-``status="*"`` to allow any status.
+``status="*"`` to allow any status, or ``status="400 Custom Bad Request"``
+to use custom reason phrase.
 
 If you expect errors to be printed, use ``expect_errors=True``.

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -109,6 +109,13 @@ class TestStatus(unittest.TestCase):
         self.assertEqual(self.check_status('200 Ok', None), None)
         self.assertRaises(webtest.AppError, self.check_status, '400 Ok')
 
+    def test_check_status_with_custom_reason(self):
+        self.assertEqual(self.check_status('200 Ok', '200 Ok'), None)
+        self.assertRaises(webtest.AppError,
+                          self.check_status, '200 Ok', '200 Good Response')
+        self.assertRaises(webtest.AppError,
+                          self.check_status, '200 Ok', '400 Bad Request')
+
 
 class TestParserFeature(unittest.TestCase):
 

--- a/webtest/app.py
+++ b/webtest/app.py
@@ -643,6 +643,9 @@ class TestApp(object):
         if (isinstance(status, string_types) and '*' in status):
             if re.match(fnmatch.translate(status), res_status, re.I):
                 return
+        if isinstance(status, string_types):
+            if status == res_status:
+                return
         if isinstance(status, (list, tuple)):
             if res.status_int not in status:
                 raise AppError(


### PR DESCRIPTION
This pull request would allow checking custom reason phrase more easily with this syntax:

```
    app.get(url, body, status='456 My Custom Reason Phrase')
```

previously, this had to be implemented as:

```
    resp = app.get(url, body, status='*')
    assert resp.status == '456 My Custom Reason Phrase'
```
