### PR TITLE
Properly check for default cookiejar arguments.

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -173,6 +173,11 @@ class TestPasteVariables(unittest.TestCase):
 
 class TestCookies(unittest.TestCase):
 
+    def test_supports_providing_cookiejar(self):
+        cookiejar = six.moves.http_cookiejar.CookieJar()
+        app = webtest.TestApp(debug_app, cookiejar=cookiejar)
+        self.assertIs(cookiejar, app.cookiejar)
+
     def test_set_cookie(self):
         def cookie_app(environ, start_response):
             req = Request(environ)

--- a/webtest/app.py
+++ b/webtest/app.py
@@ -172,8 +172,9 @@ class TestApp(object):
             extra_environ = {}
         self.extra_environ = extra_environ
         self.use_unicode = use_unicode
-        self.cookiejar = cookiejar or http_cookiejar.CookieJar(
-            policy=CookiePolicy())
+        if cookiejar is None:
+            cookiejar = http_cookiejar.CookieJar(policy=CookiePolicy())
+        self.cookiejar = cookiejar
         if parser_features is None:
             parser_features = 'html.parser'
         self.RequestClass.ResponseClass.parser_features = parser_features


### PR DESCRIPTION
`CookieJar`s are falsy when they're empty, so this was just broken.
