### PR TITLE
Avoid raising encoding errors from debugapp

### DIFF
--- a/webtest/debugapp.py
+++ b/webtest/debugapp.py
@@ -46,7 +46,7 @@ class DebugApp(object):
 
             body = ''.join(parts)
             if not isinstance(body, six.binary_type):
-                body = body.encode('ascii')
+                body = body.encode('latin1')
 
             if req.content_length:
                 body += six.b('-- Body ----------\n')


### PR DESCRIPTION
This is needed to write WSGIProxy2 tests with quoted utf8 paths.
