### PR TITLE
reset values of select multiple

### DIFF
--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -720,6 +720,20 @@ class TestSelect(unittest.TestCase):
         display = multiple_form.submit("button")
         self.assertIn("<p>You selected Nine, Ten</p>", display, display)
 
+    def test_multiple_select_reset_value(self):
+        app = webtest.TestApp(select_app_without_values)
+        res = app.get('/')
+        self.assertEqual(res.status_int, 200)
+        self.assertEqual(res.headers['content-type'],
+                         'text/html; charset=utf-8')
+        self.assertEqual(res.content_type, 'text/html')
+
+        multiple_form = res.forms["multiple_select_form"]
+        self.assertEqual(multiple_form["multiple"].value, ["Nine", "Eleven"])
+        multiple_form["multiple"].force_value(None)
+        self.assertIsNone(multiple_form["multiple"].value)
+        display = multiple_form.submit("button")
+        self.assertIn("<p>You selected </p>", display, display)
 
 class SingleUploadFileApp(object):
 

--- a/webtest/forms.py
+++ b/webtest/forms.py
@@ -167,7 +167,7 @@ class MultipleSelect(Field):
         self.options = []
         # Undetermined yet:
         self.selectedIndices = []
-        self._forced_values = []
+        self._forced_values = NoValue
 
     def force_value(self, values):
         """Like setting a value, except forces it (even for, say, hidden
@@ -215,21 +215,16 @@ class MultipleSelect(Field):
                    ', '.join([repr(o) for o, c, t in self.options])))
 
     def value__get(self):
-        selected_values = []
-        if self.selectedIndices:
-            selected_values = [self.options[i][0]
-                               for i in self.selectedIndices]
-        elif not self._forced_values:
+        if self._forced_values is not NoValue:
+            return self._forced_values
+        elif self.selectedIndices:
+            return [self.options[i][0] for i in self.selectedIndices]
+        else:
             selected_values = []
             for option, checked, text in self.options:
                 if checked:
                     selected_values.append(option)
-        if self._forced_values:
-            selected_values += self._forced_values
-
-        if self.options and (not selected_values):
-            selected_values = None
-        return selected_values
+            return selected_values if selected_values else None
     value = property(value__get, value__set)
 
 


### PR DESCRIPTION
Hi,

If we got multiple default values for a select multiple and want to reset them (unselect them), the only way I found was to hacking the options (forcing checked flag to be false!).

Here is a purpose to achieve it.

Thanks