### PR TITLE
JSON methods respect content_type argument if passed

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -104,6 +104,13 @@ class json_methodTest(unittest.TestCase):
                                           'params': json.dumps({'a': 'b'}),
                                           'upload_files': None}))
 
+    def test_json_method_request_respects_content_type_argument(self):
+        self.assertEquals(self.mock.foo_json('url', params={'a': 'b'}, c='c', content_type='application/vnd.api+json;charset=utf-8'),
+                          ('FOO', 'url', {'content_type': 'application/vnd.api+json;charset=utf-8',
+                                          'c': 'c',
+                                          'params': json.dumps({'a': 'b'}),
+                                          'upload_files': None}))
+
     def test_json_method_doc(self):
         self.assertIn('FOO request', self.mock.foo_json.__doc__)
         self.assertIn('TestApp.foo', self.mock.foo_json.__doc__)

--- a/webtest/utils.py
+++ b/webtest/utils.py
@@ -26,12 +26,11 @@ def json_method(method):
     """
 
     def wrapper(self, url, params=NoDefault, **kw):
-        content_type = 'application/json'
+        kw.setdefault('content_type', 'application/json')
         if params is not NoDefault:
             params = dumps(params, cls=self.JSONEncoder)
         kw.update(
             params=params,
-            content_type=content_type,
             upload_files=None,
         )
         return self._gen_request(method, url, **kw)


### PR DESCRIPTION
Allows, for example: `self.post_json(url, data, content_type='application/vnd.api+json')`