### PR TITLE
support bearer auth

### DIFF
--- a/tests/test_authorisation.py
+++ b/tests/test_authorisation.py
@@ -33,9 +33,27 @@ class TestAuthorization(unittest.TestCase):
         app.authorization = None
         self.assertNotIn('HTTP_AUTHORIZATION', app.extra_environ)
 
+    def test_bearer_authorization(self):
+        app = self.callFUT()
+        authorization = ('Bearer', '2588409761fcfa3e378bff4fb766e2e2')
+        app.authorization = authorization
+
+        self.assertIn('HTTP_AUTHORIZATION', app.extra_environ)
+        self.assertEquals(app.authorization, authorization)
+
+        resp = app.get('/')
+        resp.mustcontain('HTTP_AUTHORIZATION: Bearer 2588409761fcfa3e378bff4fb766e2e2')
+        header = resp.request.environ['HTTP_AUTHORIZATION']
+        self.assertTrue(header.startswith('Bearer '))
+
+        app.authorization = None
+        self.assertNotIn('HTTP_AUTHORIZATION', app.extra_environ)
+
     def test_invalid(self):
         app = self.callFUT()
         self.assertRaises(ValueError, app.set_authorization, ())
         self.assertRaises(ValueError, app.set_authorization, '')
         self.assertRaises(ValueError, app.set_authorization, ('Basic', ''))
         self.assertRaises(ValueError, app.set_authorization, ('Basic', ()))
+        self.assertRaises(ValueError, app.set_authorization, ('Bearer', ()))
+        self.assertRaises(ValueError, app.set_authorization, ('Bearer', []))

--- a/webtest/app.py
+++ b/webtest/app.py
@@ -206,7 +206,7 @@ class TestApp(object):
                     val = b64encode(to_bytes(val)).strip()
                     val = val.decode('latin1')
                 elif authtype == 'Bearer' and val and \
-                        isinstance(val, text_type):
+                        isinstance(val, (str, text_type)):
                     val = val.strip()
                 else:
                     raise ValueError(invalid_value)

--- a/webtest/app.py
+++ b/webtest/app.py
@@ -205,17 +205,9 @@ class TestApp(object):
                     val = ':'.join(list(val))
                     val = b64encode(to_bytes(val)).strip()
                     val = val.decode('latin1')
-                elif authtype == 'Bearer':
-                    if sys.version_info >= (3, 0, 0):
-                        if val and isinstance(val, str):
-                            val = val.strip()
-                        else:
-                            raise ValueError(invalid_value)
-                    else:
-                        if val and isinstance(val, (str, unicode)):
-                            val = val.strip()
-                        else:
-                            raise ValueError(invalid_value)
+                elif authtype == 'Bearer' and val and \
+                        isinstance(val, text_type):
+                    val = val.strip()
                 else:
                     raise ValueError(invalid_value)
                 value = str('%s %s' % (authtype, val))

--- a/webtest/app.py
+++ b/webtest/app.py
@@ -204,6 +204,8 @@ class TestApp(object):
                     val = ':'.join(list(val))
                     val = b64encode(to_bytes(val)).strip()
                     val = val.decode('latin1')
+                elif authtype == 'Bearer' and val and isinstance(val, (str, unicode)):
+                    val = val.strip()
                 else:
                     raise ValueError(invalid_value)
                 value = str('%s %s' % (authtype, val))

--- a/webtest/app.py
+++ b/webtest/app.py
@@ -11,6 +11,7 @@ from __future__ import unicode_literals
 
 import os
 import re
+import sys
 import json
 import random
 import fnmatch
@@ -195,7 +196,7 @@ class TestApp(object):
         self.authorization_value = value
         if value is not None:
             invalid_value = (
-                "You should use a value like ('Basic', ('user', 'password'))"
+                "You should use a value like ('Basic', ('user', 'password')) OR ('Bearer', 'token')"
             )
             if isinstance(value, (list, tuple)) and len(value) == 2:
                 authtype, val = value
@@ -204,8 +205,17 @@ class TestApp(object):
                     val = ':'.join(list(val))
                     val = b64encode(to_bytes(val)).strip()
                     val = val.decode('latin1')
-                elif authtype == 'Bearer' and val and isinstance(val, (str, unicode)):
-                    val = val.strip()
+                elif authtype == 'Bearer':
+                    if sys.version_info >= (3, 0, 0):
+                        if val and isinstance(val, str):
+                            val = val.strip()
+                        else:
+                            raise ValueError(invalid_value)
+                    else:
+                        if val and isinstance(val, (str, unicode)):
+                            val = val.strip()
+                        else:
+                            raise ValueError(invalid_value)
                 else:
                     raise ValueError(invalid_value)
                 value = str('%s %s' % (authtype, val))


### PR DESCRIPTION
Allow bearer auth in the authentication header. This is useful in testing webapps which authenticate via token as opposed to basic auth.