### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,4 +8,4 @@ requests to that application, without starting up an HTTP server.
 This provides convenient full-stack testing of applications written
 with any WSGI-compatible framework.
 
-Full docs can be found at https://webtest.readthedocs.org/en/latest/
+Full docs can be found at https://webtest.readthedocs.io/en/latest/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,8 +29,8 @@ extensions = ['sphinx.ext.autodoc', 'sphinx.ext.viewcode', 'sphinx.ext.intersphi
 
 intersphinx_mapping = {
     'python': ('http://docs.python.org/2.7', None),
-    'webob': ('https://webob.readthedocs.org/en/latest', None),
-    'waitrress': ('https://waitress.readthedocs.org/en/latest', None),
+    'webob': ('https://webob.readthedocs.io/en/latest', None),
+    'waitrress': ('https://waitress.readthedocs.io/en/latest', None),
 }
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.