### PR TITLE
Fix docs errors

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -124,7 +124,7 @@ html_theme = 'nature'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = []
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -107,7 +107,7 @@ Or response's body::
     >>> resp.mustcontain('<html>')
     >>> assert 'form' in resp
 
-WebTest can do much more. In particular, it can handle :doc:`forms` and :doc:`json`.
+WebTest can do much more. In particular, it can handle :doc:`forms`.
 
 
 Contents

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -66,7 +66,7 @@ run WSGI applications and verify the output.
 Quick start
 ===========
 
-The most important object in WebTest is :class:`~webtest.TestApp`, the wrapper
+The most important object in WebTest is :class:`~webtest.app.TestApp`, the wrapper
 for WSGI applications. It also allows you to perform HTTP requests on it.
 To use it, you simply instantiate it with your WSGI application.
 
@@ -83,7 +83,7 @@ Here is a basic application::
     ...     start_response('200 OK', headers)
     ...     return [body]
 
-Wrap it into a :class:`~webtest.TestApp`::
+Wrap it into a :class:`~webtest.app.TestApp`::
 
     >>> from webtest import TestApp
     >>> app = TestApp(application)

--- a/docs/testapp.rst
+++ b/docs/testapp.rst
@@ -10,10 +10,10 @@ To make a request, use:
 
     app.get('/path', [params], [headers], [extra_environ], ...)
 
-This call to :meth:`~webtest.TestApp.get` does a request for
+This call to :meth:`~webtest.app.TestApp.get` does a request for
 ``/path``, with any params, extra headers or WSGI
 environment keys that you indicate.  This returns a
-:class:`~webtest.TestResponse` object,
+:class:`~webtest.response.TestResponse` object,
 based on :class:`webob.response.Response`.  It has some
 additional methods to make it easier to test.
 
@@ -24,7 +24,7 @@ If you want to do a POST request, use:
     app.post('/path', {'vars': 'values'}, [headers], [extra_environ],
              [upload_files], ...)
 
-Specifically the second argument of :meth:`~webtest.TestApp.post`
+Specifically the second argument of :meth:`~webtest.app.TestApp.post`
 is the *body* of the request.  You
 can pass in a dictionary (or dictionary-like object), or a string
 body (dictionary objects are turned into HTML form submissions).
@@ -33,8 +33,8 @@ You can also pass in the keyword argument upload_files, which is a
 list of ``[(fieldname, filename, field_content)]``.  File uploads use a
 different form submission data type to pass the structured data.
 
-You can use :meth:`~webtest.TestApp.put` and
-:meth:`~webtest.TestApp.delete` for PUT and DELETE requests.
+You can use :meth:`~webtest.app.TestApp.put` and
+:meth:`~webtest.app.TestApp.delete` for PUT and DELETE requests.
 
 
 Making JSON Requests
@@ -45,10 +45,10 @@ Webtest provide some facilities to test json apis.
 The ``*_json`` methods will transform data to json before ``POST``/``PUT`` and
 add the correct ``Content-Type`` for you.
 
-Also Response have an attribute ``.json`` to allow you to retrieve json
+Also Response have an attribute :attr:`~webtest.response.TestResponse.json` to allow you to retrieve json
 contents as a python dict.
 
-Doing *POST* request with :meth:`webtest.TestApp.post_json`:
+Doing *POST* request with :meth:`webtest.app.TestApp.post_json`:
 
 .. code-block:: python
 
@@ -63,7 +63,7 @@ Doing *POST* request with :meth:`webtest.TestApp.post_json`:
     True
 
 
-Doing *GET* request with :meth:`webtest.TestApp.get` and using :attr:`webtest.response.json`:
+Doing *GET* request with :meth:`webtest.app.TestApp.get` and using :attr:`~webtest.response.TestResponse.json`:
 
 To just parse body of the response, use Response.json:
 

--- a/docs/testresponse.rst
+++ b/docs/testresponse.rst
@@ -33,13 +33,13 @@ The added methods:
 ``response.follow(**kw)``:
     Follows the redirect, returning the new response.  It is an error
     if this response wasn't a redirect. All keyword arguments are
-    passed to :class:`webtest.TestApp` (e.g., ``status``). Returns
+    passed to :class:`webtest.app.TestApp` (e.g., ``status``). Returns
     another response object.
 
 ``response.maybe_follow(**kw)``:
     Follows all redirects; does nothing if this response
     is not a redirect. All keyword arguments are passed
-    to :class:`webtest.TestApp` (e.g., ``status``). Returns another
+    to :class:`webtest.app.TestApp` (e.g., ``status``). Returns another
     response object.
 
 ``x in response``:
@@ -62,7 +62,7 @@ The added methods:
     `doctest <http://python.org/doc/current/lib/module-doctest.html>`_
 
 ``response.click(description=None, linkid=None, href=None, anchor=None, index=None, verbose=False)``:
-    Clicks the described link (see :class:`~webtest.TestResponse.click`)
+    Clicks the described link (see :meth:`~webtest.response.TestResponse.click`)
 
 ``response.forms``:
     Return a dictionary of forms; you can use both indexes (refer to


### PR DESCRIPTION
Hi. Thanks for this awesome project.
I saw [the document](http://docs.pylonsproject.org/projects/webtest/en/latest/index.html) and found some errors in it.

* Invalid links for it's module index
* An invalid link for deleted document
* Errors on building caused by `_static` dir setting
