### PR TITLE
Remove remaining references to ordereddict package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,9 +19,6 @@ tests_require = [
     'PasteDeploy', 'WSGIProxy2', 'pyquery'
 ]
 
-if sys.version_info[0:2] < (2, 7):
-    install_requires.append('ordereddict')
-
 
 setup(name='WebTest',
       version=version,

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -4,7 +4,7 @@ from webob import Request
 from webob import Response
 from webtest.compat import to_bytes
 from webtest.compat import PY3
-from webtest.compat import OrderedDict
+from collections import OrderedDict
 from webtest.debugapp import debug_app
 from webtest import http
 from tests.compat import unittest

--- a/webtest/compat.py
+++ b/webtest/compat.py
@@ -35,11 +35,6 @@ def print_stderr(value):
             value = value.encode('utf8')
     six.print_(value, file=sys.stderr)
 
-try:
-    from collections import OrderedDict
-except ImportError:  # pragma: no cover
-    from ordereddict import OrderedDict  # noqa
-
 
 def escape_cookie_value(value):
     """

--- a/webtest/forms.py
+++ b/webtest/forms.py
@@ -5,7 +5,7 @@ import re
 import sys
 
 from bs4 import BeautifulSoup
-from webtest.compat import OrderedDict
+from collections import OrderedDict
 from webtest import utils
 
 


### PR DESCRIPTION
Now that Python 2.6 is unsupported, references to the ordereddict
package can be removed in preference of using OrderedDict from the
Python standard library's collections module.