### PR TITLE
Improves linting to validate headers are 'native' string type

### DIFF
--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -321,6 +321,8 @@ def select_app(environ, start_response):
     headers = [
         ('Content-Type', 'text/html; charset=utf-8'),
         ('Content-Length', str(len(body)))]
+    # PEP 3333 requires native strings:
+    headers = [(str(k), str(v)) for k, v in headers]
     start_response(status, headers)
     return [body]
 
@@ -373,6 +375,8 @@ def select_app_without_values(environ, start_response):
     headers = [
         ('Content-Type', 'text/html; charset=utf-8'),
         ('Content-Length', str(len(body)))]
+    # PEP 3333 requires native strings:
+    headers = [(str(k), str(v)) for k, v in headers]
     start_response(status, headers)
     return [body]
 
@@ -425,6 +429,8 @@ def select_app_without_default(environ, start_response):
     headers = [
         ('Content-Type', 'text/html; charset=utf-8'),
         ('Content-Length', str(len(body)))]
+    # PEP 3333 requires native strings:
+    headers = [(str(k), str(v)) for k, v in headers]
     start_response(status, headers)
     return [body]
 
@@ -476,6 +482,8 @@ def select_app_unicode(environ, start_response):
     headers = [
         ('Content-Type', 'text/html; charset=utf-8'),
         ('Content-Length', str(len(body)))]
+    # PEP 3333 requires native strings:
+    headers = [(str(k), str(v)) for k, v in headers]
     start_response(status, headers)
     if not isinstance(body, binary_type):
         raise AssertionError('Body is not %s' % binary_type)
@@ -770,6 +778,8 @@ class SingleUploadFileApp(object):
         headers = [
             ('Content-Type', 'text/html; charset=utf-8'),
             ('Content-Length', str(len(body)))]
+        # PEP 3333 requires native strings:
+        headers = [(str(k), str(v)) for k, v in headers]
         start_response(status, headers)
         assert(isinstance(body, binary_type))
         return [body]

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -143,13 +143,33 @@ class TestCheckContentType(unittest.TestCase):
 
 class TestCheckHeaders(unittest.TestCase):
 
-    @unittest.skipIf(not PY3, 'Useless in Python2')
-    def test_header_unicode_value(self):
-        self.assertRaises(AssertionError, check_headers, [('X-Price', '100€')])
-
-    @unittest.skipIf(not PY3, 'Useless in Python2')
+    @unittest.skipIf(PY3, 'unicode is str in Python3')
     def test_header_unicode_name(self):
-        self.assertRaises(AssertionError, check_headers, [('X-€', 'foo')])
+        headers = [(u'X-Price', str('100'))]
+        self.assertRaises(AssertionError, check_headers, headers)
+
+    @unittest.skipIf(PY3, 'unicode is str in Python3')
+    def test_header_unicode_value(self):
+        headers = [(str('X-Price'), u'100')]
+        self.assertRaises(AssertionError, check_headers, headers)
+
+    @unittest.skipIf(not PY3, 'bytes is str in Python2')
+    def test_header_bytes_name(self):
+        headers = [(b'X-Price', '100')]
+        self.assertRaises(AssertionError, check_headers, headers)
+
+    @unittest.skipIf(not PY3, 'bytes is str in Python2')
+    def test_header_bytes_value(self):
+        headers = [('X-Price', b'100')]
+        self.assertRaises(AssertionError, check_headers, headers)
+
+    def test_header_non_latin1_value(self):
+        headers = [(str('X-Price'), '100€')]
+        self.assertRaises(AssertionError, check_headers, headers)
+
+    def test_header_non_latin1_name(self):
+        headers = [('X-€', str('foo'))]
+        self.assertRaises(AssertionError, check_headers, headers)
 
 
 class TestCheckEnviron(unittest.TestCase):

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -114,6 +114,8 @@ class TestMiddleware2(unittest.TestCase):
             headers = [
                 ('Content-Type', 'text/plain; charset=utf-8'),
                 ('Content-Length', str(len(body)))]
+            # PEP 3333 requires native strings:
+            headers = [(str(k), str(v)) for k, v in headers]
             start_response(to_bytes('200 OK'), headers, ('stuff',))
             return [body]
 

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -115,7 +115,8 @@ def links_app(environ, start_response):
     ]
     if req.path_info in utf8_paths:
         headers[0] = ('Content-Type', str('text/html; charset=utf-8'))
-
+    # PEP 3333 requires native strings:
+    headers = [(str(k), str(v)) for k, v in headers]
     start_response(str(status), headers)
     return [body]
 
@@ -127,7 +128,8 @@ def gzipped_app(environ, start_response):
         ('Content-Type', str('text/html')),
         ('Content-Encoding', str('gzip')),
     ]
-
+    # PEP 3333 requires native strings:
+    headers = [(str(k), str(v)) for k, v in headers]
     start_response(str(status), headers)
     return encoded_body
 
@@ -423,6 +425,8 @@ class TestFollow(unittest.TestCase):
                 remaining_redirects[0] -= 1
 
             headers.append(('Content-Length', str(len(body))))
+            # PEP 3333 requires native strings:
+            headers = [(str(k), str(v)) for k, v in headers]
             start_response(str(status), headers)
             return [body]
 


### PR DESCRIPTION
Fixes #119

According to [PEP 3333](https://www.python.org/dev/peps/pep-3333/#a-note-on-string-types),

> "Native" strings (which are always implemented using the type named str ) that are **used for request/response headers** and metadata

Currently, in Python2, `TestApp` does not validate that a WSGI application being tested is returning native strings for headers. This pull request adds that check.