### PR TITLE
Fix strict cookie policy.

### DIFF
--- a/webtest/app.py
+++ b/webtest/app.py
@@ -69,13 +69,13 @@ class CookiePolicy(http_cookiejar.DefaultCookiePolicy):
     Domain=localhost."""
 
     def return_ok_domain(self, cookie, request):
-        if cookie.domain.endswith(request.origin_req_host):
+        if cookie.domain == '.localhost':
             return True
         return http_cookiejar.DefaultCookiePolicy.return_ok_domain(
             self, cookie, request)
 
     def set_ok_domain(self, cookie, request):
-        if cookie.domain.endswith(request.origin_req_host):
+        if cookie.domain == '.localhost':
             return True
         return http_cookiejar.DefaultCookiePolicy.set_ok_domain(
             self, cookie, request)
@@ -231,9 +231,10 @@ class TestApp(object):
         Sets a cookie to be passed through with requests.
 
         """
-        cookie_domain = self.extra_environ.get('HTTP_HOST', 'localhost')
+        cookie_domain = self.extra_environ.get('HTTP_HOST', '.localhost')
         cookie_domain = cookie_domain.split(':', 1)[0]
-        cookie_domain = '.' + cookie_domain
+        if '.' not in cookie_domain:
+            cookie_domain = "%s.local" % cookie_domain
         value = escape_cookie_value(value)
         cookie = http_cookiejar.Cookie(
             version=0,

--- a/webtest/utils.py
+++ b/webtest/utils.py
@@ -97,7 +97,7 @@ class _RequestCookieAdapter(object):
     """
     def __init__(self, request):
         self._request = request
-        self.origin_req_host = request.host.split(':')[0]
+        self.origin_req_host = request.host
 
     def is_unverifiable(self):
         return True  # sure? Why not?


### PR DESCRIPTION
The zope.testbrowser tests are affected by this, see https://github.com/zopefoundation/zope.testbrowser/commit/8e3c130778320650076b57f956fe55907cc1c784 and https://travis-ci.org/zopefoundation/zope.testbrowser/jobs/226375649.

The commit b35063f1bc6f6b0cd92b68c56838f385b56e8d00 added a shortcut that breaks strict cookie policies.
If one uses a trailing dot in HTTP_HOST when the domain is not a FQDN, then it works without the shortcut and the strict policy works as well.

@gawel since you made the commit, could you take a look at this?