### PR TITLE
Add ``Email`` class for input fields with type "email".

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ News
 2.0.30 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Add ``Email`` class for input fields with type "email".
 
 
 2.0.29 (2017-10-21)

--- a/webtest/forms.py
+++ b/webtest/forms.py
@@ -293,6 +293,10 @@ class Text(Field):
     """Field representing ``<input type="text">``"""
 
 
+class Email(Field):
+    """Field representing ``<input type="email">``"""
+
+
 class File(Field):
     """Field representing ``<input type="file">``"""
 
@@ -347,6 +351,8 @@ Field.classes['hidden'] = Hidden
 Field.classes['file'] = File
 
 Field.classes['text'] = Text
+
+Field.classes['email'] = Email
 
 Field.classes['password'] = Text
 


### PR DESCRIPTION
Currently instances belonging to such fields have the plain `Field` class.