### PR TITLE
Docs cleanup, take 2!

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,4 +8,4 @@ requests to that application, without starting up an HTTP server.
 This provides convenient full-stack testing of applications written
 with any WSGI-compatible framework.
 
-Full docs can be found at https://webtest.readthedocs.io/en/latest/
+Full docs can be found at https://docs.pylonsproject.org/projects/webtest/en/latest/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -179,6 +179,14 @@ smartquotes = False
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'WebTestdoc'
 
+# Control display of sidebars
+html_sidebars = { '**': [
+    'localtoc.html',
+    'ethicalads.html',
+    'relations.html',
+    'sourcelink.html',
+    'searchbox.html',
+] }
 
 # -- Options for LaTeX output --------------------------------------------------
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ tests_require = [
 docs_extras = [
     'Sphinx >= 1.7.9',
     'docutils',
-    'pylons-sphinx-themes',
+    'pylons-sphinx-themes >= 1.0.8',
 ]
 
 setup(name='WebTest',

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ tests_require = [
 ]
 
 docs_extras = [
-    'Sphinx >= 1.7.9',
+    'Sphinx >= 1.8.1',
     'docutils',
     'pylons-sphinx-themes >= 1.0.8',
 ]
@@ -43,13 +43,14 @@ setup(name='WebTest',
           "Programming Language :: Python :: 3.4",
           "Programming Language :: Python :: 3.5",
           "Programming Language :: Python :: 3.6",
+          "Programming Language :: Python :: 3.7",
       ],
       keywords='wsgi test unit tests web',
       author='Ian Bicking',
       author_email='ianb at colorstudy com',
       maintainer='Gael Pasgrimaud',
       maintainer_email='gael@gawel.org',
-      url='http://webtest.pythonpaste.org/',
+      url='https://docs.pylonsproject.org/projects/webtest/en/latest/',
       license='MIT',
       packages=find_packages(exclude=[
           'ez_setup',


### PR DESCRIPTION
See #198

We're now using `docs.pylonsproject.org` as the canonical URL for all docs under the Pylons Project. We have https, and we have stats.

We've also made an agreement with RTD to display Ethical Ads, if you like. If not, just disable it in `docs/conf.py`. RTD will share one-half of its ad revenue that Pylons Project docs generate with the PSF.