### PR TITLE
Fix deprecation warnings for ``collections`` to use ``collections.abc``

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,8 @@ News
 2.0.33 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fixed #196. Fix deprecation warnings for ``collections`` to use
+  ``collections.abc`` for ``Iterable`` on Python 3.
 
 
 2.0.32 (2018-10-05)

--- a/webtest/compat.py
+++ b/webtest/compat.py
@@ -21,12 +21,14 @@ if PY3:  # pragma: no cover
     from urllib.parse import splittype
     from urllib.parse import splithost
     import urllib.parse as urlparse
+    from collections.abc import Iterable  # noqa
 else:  # pragma: no cover
     from htmlentitydefs import name2codepoint  # noqa
     from urllib import splittype  # noqa
     from urllib import splithost  # noqa
     from urllib import urlencode  # noqa
     import urlparse  # noqa
+    from collections import Iterable  # noqa
 
 
 def print_stderr(value):

--- a/webtest/lint.py
+++ b/webtest/lint.py
@@ -116,13 +116,14 @@ Some of the things this checks:
 """
 from __future__ import unicode_literals
 
-import collections
 import re
 import warnings
 from six import PY3
 from six import binary_type
 from six import string_types
 from six import text_type
+
+from webtest.compat import Iterable
 
 header_re = re.compile(r'^[a-zA-Z][a-zA-Z0-9\-_]*$')
 bad_header_value_re = re.compile(r'[\000-\037]')
@@ -198,7 +199,7 @@ def middleware(application, global_conf=None):
         environ['wsgi.errors'] = ErrorWrapper(environ['wsgi.errors'])
 
         iterator = application(environ, start_response_wrapper)
-        assert isinstance(iterator, collections.Iterable), (
+        assert isinstance(iterator, Iterable), (
             "The application must return an iterator, if only an empty list")
 
         check_iterator(iterator)


### PR DESCRIPTION
for ``Iterable`` on Python 3.

See #196.