### PR TITLE
Fix DeprecationWarning: invalid escape sequence \s

### DIFF
--- a/webtest/forms.py
+++ b/webtest/forms.py
@@ -409,7 +409,7 @@ class Form(object):
 
     _tag_re = re.compile(r'<(/?)([a-z0-9_\-]*)([^>]*?)>', re.I)
     _label_re = re.compile(
-        '''<label\s+(?:[^>]*)for=(?:"|')([a-z0-9_\-]+)(?:"|')(?:[^>]*)>''',
+        r'''<label\s+(?:[^>]*)for=(?:"|')([a-z0-9_\-]+)(?:"|')(?:[^>]*)>''',
         re.I)
 
     FieldClass = Field


### PR DESCRIPTION
Running tests on Travis for my package was showing this deprecation warning. To reproduce locally run with `python -Wd`.