### PR TITLE
Use truth test instead of length == 0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ News
 2.0.34 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fix the test ``length == 0`` in ``check_content_type``.
 
 
 2.0.33 (2019-02-09)

--- a/webtest/lint.py
+++ b/webtest/lint.py
@@ -534,7 +534,7 @@ def check_content_type(status, headers):
         if name.lower() == 'content-type':
             if code not in NO_MESSAGE_TYPE:
                 return
-            elif length == 0:
+            elif not length:
                 warnings.warn(("Content-Type header found in a %s response, "
                                "which not return content.") % code,
                               WSGIWarning)


### PR DESCRIPTION
`length` is initially set to `None`. When there is no `Content-Length` header, `length` will still be `None`. So the test `length == 0` is not entirely correct.