### PR TITLE
Fix bad variable name in check_header

### DIFF
--- a/webtest/lint.py
+++ b/webtest/lint.py
@@ -515,7 +515,7 @@ def check_headers(headers):
         if bad_header_value_re.search(value):
             raise AssertionError(
                 "Bad header value: %r (bad char: %r)"
-                % (str_value, bad_header_value_re.search(value).group(0))
+                % (value, bad_header_value_re.search(value).group(0))
             )
 
 


### PR DESCRIPTION
In commit 7d539b6 there is a mistake during refactoring.
Line str_value = to_string(value) was removed, but reference to str_value is still in code. This reference should be changed to value instead.