### PR TITLE
Support <input type="search">

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,8 @@ News
 
 - Fix the test ``length == 0`` in ``check_content_type``.
 
+- Treat ``<input type="search">`` like ``<input type="text">``.
+
 
 2.0.33 (2019-02-09)
 -------------------

--- a/webtest/forms.py
+++ b/webtest/forms.py
@@ -356,6 +356,8 @@ Field.classes['file'] = File
 
 Field.classes['text'] = Text
 
+Field.classes['search'] = Text
+
 Field.classes['email'] = Email
 
 Field.classes['password'] = Text


### PR DESCRIPTION
https://html.spec.whatwg.org/multipage/input.html#text-(type=text)-state-and-search-state-(type=search)
describes the difference between `type="text"` and `type="search"` as
being primarily stylistic.