### PR TITLE
Remove use of deprecated splittype and splithost

### DIFF
--- a/webtest/compat.py
+++ b/webtest/compat.py
@@ -18,14 +18,10 @@ def to_bytes(value, charset='latin1'):
 if PY3:  # pragma: no cover
     from html.entities import name2codepoint
     from urllib.parse import urlencode
-    from urllib.parse import splittype
-    from urllib.parse import splithost
     import urllib.parse as urlparse
     from collections.abc import Iterable  # noqa
 else:  # pragma: no cover
     from htmlentitydefs import name2codepoint  # noqa
-    from urllib import splittype  # noqa
-    from urllib import splithost  # noqa
     from urllib import urlencode  # noqa
     import urlparse  # noqa
     from collections import Iterable  # noqa

--- a/webtest/response.py
+++ b/webtest/response.py
@@ -5,8 +5,6 @@ from json import loads
 from webtest import forms
 from webtest import utils
 from webtest.compat import print_stderr
-from webtest.compat import splittype
-from webtest.compat import splithost
 from webtest.compat import PY3
 from webtest.compat import urlparse
 from webtest.compat import to_bytes
@@ -84,8 +82,6 @@ class TestResponse(webob.Response):
     def _follow(self, **kw):
         location = self.headers['location']
         abslocation = urlparse.urljoin(self.request.url, location)
-        type_, rest = splittype(abslocation)
-        host, path = splithost(rest)
         # @@: We should test that it's not a remote redirect
         return self.test_app.get(abslocation, **kw)
 


### PR DESCRIPTION
The lines of code which made use of these methods doesn't have any effect so
can just be removed.

I originally looked into changing how these methods were used for fixing #217 but instead found that it didn't have any effect so I removed it instead.