### PR TITLE
Prevent PytestCollectionWarning for TestApp

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -19,6 +19,9 @@ class TestApp(unittest.TestCase):
     def setUp(self):
         self.app = webtest.TestApp(debug_app)
 
+    def test_pytest_collection_disabled(self):
+        self.assertFalse(webtest.TestApp.__test__)
+
     def test_encode_multipart_relative_to(self):
         app = webtest.TestApp(debug_app,
                               relative_to=os.path.dirname(__file__))

--- a/webtest/app.py
+++ b/webtest/app.py
@@ -141,6 +141,9 @@ class TestApp(object):
 
     RequestClass = TestRequest
 
+    # Tell pytest not to collect this class as tests
+    __test__ = False
+
     def __init__(self, app, extra_environ=None, relative_to=None,
                  use_unicode=True, cookiejar=None, parser_features=None,
                  json_encoder=None, lint=True):


### PR DESCRIPTION
As per my blog post: https://adamj.eu/tech/2020/07/28/how-to-fix-a-pytest-collection-warning-about-web-tests-test-app-class/

pytest tries to collect `TestApp` where it's imported and raises a warning when it finds it's not a test class. Users currently have to work around this, but it can be solved here by addition of this attribute.