### PR TITLE
Clean-up after dropping Python 2 support.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,8 +1,8 @@
 News
 ====
 
-2.0.36 (unreleased)
--------------------
+3.0.0 (unreleased)
+------------------
 
 - Dropped support for Python 2.7 and 3.5.
 
@@ -519,7 +519,7 @@ News
 * Fix `#14 and #18 <https://bitbucket.org/ianb/webtest/issues/18>`_ Allow to use
   `.delete(params={})`
 
-* Fix `#12 <https://bitbucket.org/ianb/webtest/issues/12>`_ 
+* Fix `#12 <https://bitbucket.org/ianb/webtest/issues/12>`_
 
 
 1.2.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 dev = develop easy_install webtest[tests]
 
 [bdist_wheel]
-universal=1
+universal=0
 
 [nosetests]
 verbosity=2

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 from setuptools import find_packages
 
-version = '2.0.36.dev0'
+version = '3.0.0.dev0'
 
 install_requires = [
     'WebOb>=1.2',
@@ -34,6 +34,7 @@ setup(name='WebTest',
           "Topic :: Internet :: WWW/HTTP :: WSGI",
           "Topic :: Internet :: WWW/HTTP :: WSGI :: Server",
           "Programming Language :: Python :: 3",
+          "Programming Language :: Python :: 3 :: Only",
           "Programming Language :: Python :: 3.6",
           "Programming Language :: Python :: 3.7",
           "Programming Language :: Python :: 3.8",
@@ -53,6 +54,7 @@ setup(name='WebTest',
       ]),
       include_package_data=True,
       zip_safe=False,
+      python_requires='>=3.6, <4',
       install_requires=install_requires,
       test_suite='nose.collector',
       tests_require=tests_require,


### PR DESCRIPTION
These are the things I'd suggest to do additionally when dropping Python 2
support. They ensure that users still using Python 2 do not accidentally
install this new version.