### PR TITLE
Remove all references to thte six package

### DIFF
--- a/docs/testapp.rst
+++ b/docs/testapp.rst
@@ -3,7 +3,6 @@ TestApp
 
 ..
   >>> import json
-  >>> import six
   >>> import sys
   >>> from webtest.app import TestApp
   >>> from webob import Request
@@ -12,16 +11,16 @@ TestApp
   ...     req = Request(environ)
   ...     if req.path_info.endswith('.html'):
   ...         content_type = 'text/html'
-  ...         body = six.b('<html><body><div id="content">hey!</div></body>')
+  ...         body = '<html><body><div id="content">hey!</div></body>'.encode('latin-1')
   ...     elif req.path_info.endswith('.xml'):
   ...         content_type = 'text/xml'
-  ...         body = six.b('<xml><message>hey!</message></xml>')
+  ...         body = '<xml><message>hey!</message></xml>'.encode('latin-1')
   ...     elif req.path_info.endswith('.json'):
   ...         content_type = 'application/json'
-  ...         body = six.b(json.dumps({"a": 1, "b": 2}))
+  ...         body = json.dumps({"a": 1, "b": 2}).encode('latin-1')
   ...     elif '/resource/' in req.path_info:
   ...         content_type = 'application/json'
-  ...         body = six.b(json.dumps(dict(id=1, value='value')))
+  ...         body = json.dumps(dict(id=1, value='value')).encode('latin-1')
   ...     resp = Response(body, content_type=content_type)
   ...     return resp(environ, start_response)
   >>> app = TestApp(application)

--- a/docs/testresponse.rst
+++ b/docs/testresponse.rst
@@ -3,7 +3,6 @@ TestResponse
 
 ..
   >>> import json
-  >>> import six
   >>> import sys
   >>> from webob import Request
   >>> from webob import Response
@@ -12,13 +11,13 @@ TestResponse
   ...     req = Request(environ)
   ...     if req.path_info.endswith('.html'):
   ...         content_type = 'text/html'
-  ...         body = six.b('<html><body><div id="content">hey!</div></body>')
+  ...         body = '<html><body><div id="content">hey!</div></body>'.encode('latin-1')
   ...     elif req.path_info.endswith('.xml'):
   ...         content_type = 'text/xml'
-  ...         body = six.b('<xml><message>hey!</message></xml>')
+  ...         body = '<xml><message>hey!</message></xml>'.encode('latin-1')
   ...     elif req.path_info.endswith('.json'):
   ...         content_type = 'application/json'
-  ...         body = six.b(json.dumps({"a": 1, "b": 2}))
+  ...         body = json.dumps({"a": 1, "b": 2}).encode('latin-1')
   ...     resp = Response(body, content_type=content_type)
   ...     return resp(environ, start_response)
   >>> app = TestApp(application)

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -19,7 +19,7 @@ from webtest.lint import to_string
 from webtest.lint import middleware
 from webtest.lint import _assert_latin1_str
 
-from six import BytesIO
+from io import BytesIO
 
 
 def application(environ, start_response):

--- a/webtest/utils.py
+++ b/webtest/utils.py
@@ -1,5 +1,4 @@
 import re
-import six
 from json import dumps
 
 from webtest.compat import urlencode


### PR DESCRIPTION
Since python2 support was dropped, webtest doesn't really need `six` any more.