### PR TITLE
Support for multiple file input

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ News
 3.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Multiple file input support.
 
 
 3.0.0 (2021-08-19)

--- a/docs/forms.rst
+++ b/docs/forms.rst
@@ -197,6 +197,17 @@ You can deal with file upload by using the Upload class:
     >>> form['file'] = Upload('README.rst', b'data')
     >>> form['file'] = Upload('README.rst', b'data', 'text/x-rst')
 
+If the file field has a ``multiple`` parameter, you can pass a
+list of :class:`~webtest.forms.Upload`:
+
+.. code-block:: python
+
+    >>> from webtest import Upload
+    >>> form['files'] = [
+    ...    Upload('README.rst'),
+    ...    Upload('LICENSE.rst'),
+    ... ]
+
 Submit a form
 --------------
 

--- a/webtest/app.py
+++ b/webtest/app.py
@@ -500,7 +500,10 @@ class TestApp:
                 except:  # pragma: no cover
                     raise  # field name are always ascii
             if isinstance(value, forms.File):
-                if value.value:
+                if "multiple" in value.attrs:
+                    for file in value.value:
+                        _append_file([key] + list(file))
+                elif value.value:
                     _append_file([key] + list(value.value))
                 else:
                     # If no file was uploaded simulate an empty file with no


### PR DESCRIPTION
Support for `<input type="file" multiple=""/>`.

If a file input is multiple, expected value is a list of `Upload`.

Fixes #240