### PR TITLE
docs: Fix a few typos

### DIFF
--- a/webtest/http.py
+++ b/webtest/http.py
@@ -45,7 +45,7 @@ class StopableWSGIServer(TcpWSGIServer):
     """StopableWSGIServer is a TcpWSGIServer which run in a separated thread.
     This allow to use tools like casperjs or selenium.
 
-    Server instance have an ``application_url`` attribute formated with the
+    Server instance have an ``application_url`` attribute formatted with the
     server host and port.
     """
 

--- a/webtest/lint.py
+++ b/webtest/lint.py
@@ -152,7 +152,7 @@ def middleware(application, global_conf=None):
 
     """
     When applied between a WSGI server and a WSGI application, this
-    middleware will check for WSGI compliancy on a number of levels.
+    middleware will check for WSGI compliance on a number of levels.
     This middleware does not modify the request or response in any
     way, but will throw an AssertionError if anything seems off
     (except for a failure to close the application iterator, which


### PR DESCRIPTION
There are small typos in:
- webtest/http.py
- webtest/lint.py

Fixes:
- Should read `formatted` rather than `formated`.
- Should read `compliance` rather than `compliancy`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md