### PR TITLE
Add TestResponse.clickbutton onclick kwarg

### DIFF
--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -250,6 +250,10 @@ class TestResponse(unittest.TestCase):
             'This is foo.',
             app.get('/').clickbutton(buttonid='button1', verbose=True)
         )
+        self.assertIn(
+            'This is foo.',
+            app.get('/').clickbutton(buttonid='button3', onclick=r".*href='(.*?)'", verbose=True)
+        )
         self.assertRaises(
             IndexError,
             app.get('/').clickbutton, buttonid='button2'

--- a/webtest/response.py
+++ b/webtest/response.py
@@ -159,16 +159,18 @@ class TestResponse(webob.Response):
         return self.goto(str(found_attrs['uri']), extra_environ=extra_environ)
 
     def clickbutton(self, description=None, buttonid=None, href=None,
-                    index=None, verbose=False):
+                    onclick=None, index=None, verbose=False):
         """
         Like :meth:`~webtest.response.TestResponse.click`, except looks
         for link-like buttons.
         This kind of button should look like
         ``<button onclick="...location.href='url'...">``.
         """
+        href_extract = re.compile(onclick) if onclick else re.compile(r"location\.href='(.*?)'")
+
         found_html, found_desc, found_attrs = self._find_element(
             tag='button', href_attr='onclick',
-            href_extract=re.compile(r"location\.href='(.*?)'"),
+            href_extract=href_extract,
             content=description,
             id=buttonid,
             href_pattern=href,


### PR DESCRIPTION
## 🎯 Aim
This change allows the TestResponse to follow customised `onclick` buttons

## 📒 Notes

Currently, the `TestResponse.clickbutton` method can **only** locate elements with their `onclick` attribute matching `location\.href='(.*?)'`. This is unnecessarily prohibitive as there are use-cases where buttons may need to have customised on-click behaviours.

This change looks to provide a kwarg that allows for such customised behaviours. 

**Callers will need to pass in a regex string with one capture group.**