### PR TITLE
Removed upper bound on Python version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(name='WebTest',
       ]),
       include_package_data=True,
       zip_safe=False,
-      python_requires='>=3.7, <4',
+      python_requires='>=3.7',
       install_requires=install_requires,
       tests_require=tests_require,
       extras_require={


### PR DESCRIPTION
This is unnecessary (Python is not SemVer'ed) and breaks dependency solvers.

See https://github.com/orgs/python-poetry/discussions/3757#discussioncomment-435337 which describes someone hitting the same problem with a different package and https://github.com/nedbat/coveragepy/issues/1020 for another example.

See also https://twitter.com/codewithanthony/status/1362181541191766017

To be concrete I'm trying to set a correct bound of `python = ">=3.8.0"` in my pyproject.toml, but I get this error from poetry, caused by the upper bound in WebTest:

```
> poetry lock
Updating dependencies
Resolving dependencies... (4.7s)

The current project's Python requirement (>=3.8.0) is not compatible with some of the required packages Python requirement:
  - webtest requires Python >=3.7, <4, so it will not be satisfied for Python >=4

Because nstack depends on webtest (3.0.1.dev0) @ git+https://github.com/Pylons/webtest.git@8ef619f which requires Python >=3.7, <4, version solving failed.

```

The authors of poetry will not change this behaviour: https://github.com/python-poetry/poetry/issues/5709
