### PR TITLE
added get_json method via utils.json_method.

### DIFF
--- a/webtest/app.py
+++ b/webtest/app.py
@@ -455,6 +455,7 @@ class TestApp:
                                  upload_files=None,
                                  expect_errors=expect_errors)
 
+    get_json = utils.json_method('GET')
     post_json = utils.json_method('POST')
     put_json = utils.json_method('PUT')
     patch_json = utils.json_method('PATCH')


### PR DESCRIPTION
Some of my API calls put json data via the request body on GET requests. To test these methods I have to use 

`testapp.request('/api/...', method='GET', body=dumps(dict).encode('UTF-8')) `

For all other request methods there is a shortcut with *_json just get is missing. 