### PR TITLE
Prevent PytestCollectionWarning for TestRequest, TestResponse

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -698,3 +698,9 @@ class TestAppXhrParam(unittest.TestCase):
             resp.charset = 'ascii'
             self.assertIn('HTTP_X_REQUESTED_WITH: XMLHttpRequest',
                           resp.text)
+
+
+class TestRequest(unittest.TestCase):
+
+    def test_pytest_collection_disabled(self):
+        self.assertFalse(webtest.TestRequest.__test__)

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -492,3 +492,6 @@ class TestFollow(unittest.TestCase):
     def test_maybe_follow_infinite(self):
         app = self.get_redirects_app(100000)
         self.assertRaises(AssertionError, app.get('/').maybe_follow)
+
+    def test_pytest_collection_disabled(self):
+        self.assertFalse(webtest.TestResponse.__test__)

--- a/webtest/app.py
+++ b/webtest/app.py
@@ -76,6 +76,10 @@ class CookiePolicy(http_cookiejar.DefaultCookiePolicy):
 
 class TestRequest(webob.BaseRequest):
     """A subclass of webob.Request"""
+
+    # Tell pytest not to collect this class as tests
+    __test__ = False
+
     ResponseClass = TestResponse
 
 

--- a/webtest/response.py
+++ b/webtest/response.py
@@ -22,6 +22,9 @@ class TestResponse(webob.Response):
     _forms_indexed = None
     parser_features = 'html.parser'
 
+    # Tell pytest not to collect this class as tests
+    __test__ = False
+
     @property
     def forms(self):
         """


### PR DESCRIPTION
Prevents mildly annoying warnings in pytest of the form:
```
PytestCollectionWarning: cannot collect test class 'TestResponse' because it has a __init__ constructor (from: test/test_foo.py)
    class TestResponse(webob.Response):
```
This has already been fixed for TestApp in 03395151089dd58170f9542c99dbee6f20eeb090, but TestRequest and TestResponse were missed. But pytest will try to collect all classes whose name starts with "Test". A quick grep confirms that these three are the only webtest classes starting with "Test".