### PR TITLE
added debug kwarg to StopableWSGIServer.shutdown

### DIFF
--- a/webtest/http.py
+++ b/webtest/http.py
@@ -8,6 +8,7 @@ import logging
 import select
 import socket
 import time
+from typing import Literal
 import os
 
 from http import client
@@ -89,11 +90,12 @@ class StopableWSGIServer(TcpWSGIServer):
             if not self.was_shutdown:
                 raise
 
-    def shutdown(self):
+    def shutdown(self, debug:bool=False) -> Literal[True]:
         """Shutdown the server"""
         # avoid showing traceback related to asyncore
         self.was_shutdown = True
-        self.logger.setLevel(logging.FATAL)
+        if not debug:
+            self.logger.setLevel(logging.FATAL)
         while self._map:
             triggers = list(self._map.values())
             for trigger in triggers:


### PR DESCRIPTION
I have been running into an issue on Github Actions where shutdowns do not seem to happen correctly, and the StopableWSGIServer is still bound to a port.

I suggest adding a `debug` kwarg to shutdown, which defaults to False.  If set to True, it simply disables the changes to logging.