### PR TITLE
support HTML5 `form` attribute

### DIFF
--- a/tests/html/form_inputs.html
+++ b/tests/html/form_inputs.html
@@ -55,5 +55,11 @@ aaa</textarea>
             <button name="action" type="submit" value="activate">Activate</button>
         </form>
 
+        <input name="foo" type="text" value="early" form="outer_inputs_form">
+        <form method="POST" id="outer_inputs_form">
+            <input name="bar" type="text" value="bar">
+        </form>
+        <input name="button" type="submit" value="text" form="outer_inputs_form">
+
     </body>
 </html>

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -288,26 +288,33 @@ class TestInput(unittest.TestCase):
 class TestFormLint(unittest.TestCase):
 
     def test_form_lint(self):
-        form = webtest.Form(None, '''<form>
+        def _build_response(html):
+            return webtest.TestResponse('<body>{}</body>'.format(html))
+
+        html = '''<form>
         <input type="text" name="field"/>
-        </form>''')
+        </form>'''
+        form = webtest.Form(_build_response(html), html)
         self.assertRaises(AttributeError, form.lint)
 
-        form = webtest.Form(None, '''<form>
+        html = '''<form>
         <input type="text" id="myfield" name="field"/>
-        </form>''')
+        </form>'''
+        form = webtest.Form(_build_response(html), html)
         self.assertRaises(AttributeError, form.lint)
 
-        form = webtest.Form(None, '''<form>
+        html = '''<form>
         <label for="myfield">my field</label>
         <input type="text" id="myfield" name="field"/>
-        </form>''')
+        </form>'''
+        form = webtest.Form(_build_response(html), html)
         form.lint()
 
-        form = webtest.Form(None, '''<form>
+        html = '''<form>
         <label class="field" for="myfield" role="r">my field</label>
         <input type="text" id="myfield" name="field"/>
-        </form>''')
+        </form>'''
+        form = webtest.Form(_build_response(html), html)
         form.lint()
 
 

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -134,6 +134,9 @@ class TestForms(unittest.TestCase):
                           form.submit, "action", value="activate",
                           index=0)
 
+    def test_outer_inputs(self):
+        form = self.callFUT(formid='outer_inputs_form')
+        self.assertEqual(('foo', 'bar', 'button'), tuple(form.fields))
 
 class TestResponseFormAttribute(unittest.TestCase):
 

--- a/webtest/forms.py
+++ b/webtest/forms.py
@@ -432,7 +432,14 @@ class Form:
         fields = OrderedDict()
         field_order = []
         tags = ('input', 'select', 'textarea', 'button')
-        for pos, node in enumerate(self.html.find_all(tags)):
+        elements = self.html.find_all(tags)
+        if self.response:
+            elements.extend(
+                elt for elt in self.response.html.find_all(
+                    tags, attrs={'form': self.id})
+                if elt not in elements
+            )
+        for pos, node in enumerate(elements):
             attrs = dict(node.attrs)
             tag = node.name
             name = None

--- a/webtest/forms.py
+++ b/webtest/forms.py
@@ -432,13 +432,13 @@ class Form:
         fields = OrderedDict()
         field_order = []
         tags = ('input', 'select', 'textarea', 'button')
-        elements = self.html.find_all(tags)
+        inner_elts = self.html.find_all(tags)
         if self.response:
-            elements.extend(
-                elt for elt in self.response.html.find_all(
-                    tags, attrs={'form': self.id})
-                if elt not in elements
-            )
+            def _form_elt_filter(tag):
+                return tag in inner_elts or tag.attrs.get('form') == self.id
+            elements = self.response.html.find_all(_form_elt_filter)
+        else:
+            elements = inner_elts
         for pos, node in enumerate(elements):
             attrs = dict(node.attrs)
             tag = node.name

--- a/webtest/forms.py
+++ b/webtest/forms.py
@@ -433,12 +433,10 @@ class Form:
         field_order = []
         tags = ('input', 'select', 'textarea', 'button')
         inner_elts = self.html.find_all(tags)
-        if self.response:
-            def _form_elt_filter(tag):
-                return tag in inner_elts or tag.attrs.get('form') == self.id
-            elements = self.response.html.find_all(_form_elt_filter)
-        else:
-            elements = inner_elts
+        def _form_elt_filter(tag):
+            return tag in inner_elts or (
+                tag.attrs.get('form') == self.id and tag.name in tags)
+        elements = self.response.html.find_all(_form_elt_filter)
         for pos, node in enumerate(elements):
             attrs = dict(node.attrs)
             tag = node.name


### PR DESCRIPTION
This basically implements what was proposed by @IwanVosloo in #8. Find inputs outside the form tag itself by searching for input elements in the whole response HTML to their `form` attribute.

closes #8

This is my first PR in this repository, so if there are any style/workflow guidelines I did not recognize or misunderstood, please let me know and I'll try to improve :)
