### PR TITLE
Strip option text

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ News
 3.0.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Strip ``<option>`` text.
 
 
 3.0.4 (2025-02-03)

--- a/tests/html/form_inputs.html
+++ b/tests/html/form_inputs.html
@@ -5,7 +5,9 @@
             <select name="select">
                 <option value="value1">Value 1</option>
                 <option value="value2" selected>Value 2</option>
-                <option value="value3">Value 3</option>
+                <option value="value3">
+                    Value 3
+                </option>
             </select>
             <input type="file" name="file" />
             <input type="unknown" name="unknown" />

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -63,6 +63,12 @@ class TestForms(unittest.TestCase):
 
     def test_form_select(self):
         form = self.callFUT()
+
+        self.assertEqual(form['select'].options, [
+            ('value1', False, 'Value 1'),
+            ('value2', True, 'Value 2'),
+            ('value3', False, '\n                    Value 3\n                ')
+        ])
         form.select('select', 'value1')
 
         self.assertEqual(

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -67,7 +67,7 @@ class TestForms(unittest.TestCase):
         self.assertEqual(form['select'].options, [
             ('value1', False, 'Value 1'),
             ('value2', True, 'Value 2'),
-            ('value3', False, '\n                    Value 3\n                ')
+            ('value3', False, 'Value 3')
         ])
         form.select('select', 'value1')
 

--- a/webtest/forms.py
+++ b/webtest/forms.py
@@ -501,7 +501,7 @@ class Form:
                     field.options.append(
                         (option.attrs.get('value', option.text),
                          'selected' in option.attrs,
-                         option.text))
+                         option.text.strip()))
 
         self.field_order = field_order
         self.fields = fields


### PR DESCRIPTION
When `<option>` tags are indented in HTML output, the inner text technically contains carriage returns and space characters.

Test assertions generally want to ignore those spaces, and check the actual text.

```html
<select name="select">
    <option>
        foobar
    </option>
</select>
```

Without this patch, `form["select"].options` value would be `\n        foobar\n    `, with the patch it is simply `foobar`.