### PR TITLE
add html5 `form` attr support to changelog

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,8 @@ News
 
 - Strip ``<option>`` text.
 
+- Detect form fields outside of ``<form>`` tag associated via HTML5 ``form`` attribute.
+
 
 3.0.4 (2025-02-03)
 ------------------


### PR DESCRIPTION
I forgot to adapt the changelog in #267.

Would it be possible to have a new release on PyPI in the next weeks?