### PR TITLE
bugfix: form input discovery

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,9 @@ News
 3.0.6 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix a bug that inputs outside of a ``<form>`` tag were considered
+  belonging to that form because they had a HTML representation identical
+  to some input inside that ``<form>``.
 
 
 3.0.5 (2025-06-04)

--- a/tests/html/form_inputs.html
+++ b/tests/html/form_inputs.html
@@ -63,5 +63,9 @@ aaa</textarea>
         </form>
         <input name="button" type="submit" value="text" form="outer_inputs_form">
 
+        <!-- this input is equal (in the sense beautifulSoup checks equality)
+             to that in outer_inputs_form -->
+        <input name="bar" type="text" value="bar">
+
     </body>
 </html>

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -143,6 +143,8 @@ class TestForms(unittest.TestCase):
     def test_outer_inputs(self):
         form = self.callFUT(formid='outer_inputs_form')
         self.assertEqual(('foo', 'bar', 'button'), tuple(form.fields))
+        # check that identical input is not considered belonging to this form
+        self.assertTrue(all(len(itm) == 1 for itm in form.fields.values()))
 
 class TestResponseFormAttribute(unittest.TestCase):
 

--- a/webtest/forms.py
+++ b/webtest/forms.py
@@ -433,10 +433,15 @@ class Form:
         field_order = []
         tags = ('input', 'select', 'textarea', 'button')
         inner_elts = self.html.find_all(tags)
-        def _form_elt_filter(tag):
-            return tag in inner_elts or (
-                tag.attrs.get('form') == self.id and tag.name in tags)
-        elements = self.response.html.find_all(_form_elt_filter)
+        if self.id:
+            def _form_elt_filter(tag):
+                return tag.name in tags and any(
+                    prt.name == 'form' and prt.attrs.get('id') == self.id
+                    for prt in tag.parents
+                ) or tag.attrs.get('form') == self.id
+            elements = self.response.html.find_all(_form_elt_filter)
+        else:
+            elements = inner_elts
         for pos, node in enumerate(elements):
             attrs = dict(node.attrs)
             tag = node.name


### PR DESCRIPTION
BeatifulSoup [considers inputs as equal if they have the same HTML representation](https://beautiful-soup.readthedocs.io/en/latest/#comparing-objects-for-equality). This broke checks like `tag in list_of_tags` in an unexpected way.

In cases like

```html
        <form method="POST" id="outer_inputs_form">
            <input name="bar" type="text" value="bar">
        </form>
        <!-- this input is equal (in the sense beautifulSoup checks equality)
             to that in outer_inputs_form -->
        <input name="bar" type="text" value="bar">
```
webtest v3.0.5 consideres the outer `bar` input belonging to `outer_inputs_form`.

I'm sorry that I overlooked that in #267 .

Now, I added a test which reveals this bug, and fixed the input field discovery (which I adjusted in #267 and thereby introduced that bug).

@gawel not sure how severe that bug is, but it has the potential to break stuff if webtest is used on pages with multiple forms on one page.