### PR TITLE
tox: fix posargs substitution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,7 +109,7 @@ dependency_groups = ["dev"]
 set_env = { LC_ALL = "C", LANG = "C", COVERAGE_FILE = ".coverage.{env_name}" }
 commands = [
     ["python", "--version"],
-    ["pytest", "--cov", "{posargs}"],
+    ["pytest", "--cov", { replace = "posargs", default = ["tests/"], extend = true } ],
 ]
 
 [tool.tox.env.coverage]


### PR DESCRIPTION
The way `{posargs}` is used is not the proper way, `tox -e py313 -- --sw tests/something.py` was not working.